### PR TITLE
add saga420/temporal-encryption-converter

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -192,6 +192,7 @@ Multi-language or language-agnostic samples. (For samples in a specific lang, se
 
 - [`Courtsite/temporal-go-helpers`](https://github.com/Courtsite/temporal-go-helpers) - Collection of helpers: saga, receive Signal with timeout, drain channel.
 - [`zboralski/codecserver`](https://github.com/zboralski/codecserver) - Data Converter and Codec Server that uses Transit Secrets Engine from HashiCorp Vault.
+- [`saga420/temporal-encryption-converter`](https://github.com/saga420/temporal-encryption-converter) - The Temporal Encryption Converter is a Go package that provides secure communication and context propagation for the Temporal workflow engine, employing AES256_GCM_PBKDF2_Curve25519 and XChaCha20_Poly1305_PBKDF2_Curve25519 encryption algorithms and ZLib compression.
 
 ### Tutorials
 


### PR DESCRIPTION
URL: [saga420/temporal-encryption-converter
](https://github.com/saga420/temporal-encryption-converter)

The Temporal Encryption Converter is a comprehensive Go package for Temporal workflow engine, offering strong encryption/decryption for payloads and context propagation across workflows. It uses asymmetric cryptography for secure client-worker communication, supports key generation/derivation, employs AES256_GCM_PBKDF2_Curve25519 and XChaCha20_Poly1305_PBKDF2_Curve25519 encryption algorithms, and utilizes ZLib pre-encryption compression for payload optimization. Available for contributions under the MIT License.