### PR TITLE
add terraform provider link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -109,6 +109,7 @@ Temporal is a [durable execution system](https://youtu.be/W0Ygep6iCJY?t=609). It
 - [`alexandrevilain/temporal-operator`](https://github.com/alexandrevilain/temporal-operator) - Kubernetes operator to deploy and manage Temporal Clusters.
 - [`rross/temporal-cloud-run`](https://github.com/rross/temporal-cloud-run) - Pulumi scripts for creating and configuring a Google Cloud Project and using Cloud Build to deploy a Temporal worker and the Open Telemetry Connector in Cloud Run
 - [`northpowered/temporal-rest-executor`](https://github.com/northpowered/temporal-rest-executor) - Simple REST server (with Swagger UI) to execute any activity/workflow in Temporal namespace. Useful for development and I&T.
+- [`platacard/terraform-provider-temporal`](https://github.com/platacard/terraform-provider-temporal) - Terraform provider to manage Temporal Server resources.
 
 ## Frameworks
 


### PR DESCRIPTION
[terraform-provider-temporal](https://github.com/platacard/terraform-provider-temporal)

The Terraform provider offers a declarative approach to resource management for the Temporal Server and adds the ability to follow infrastructure as code principles.