### PR TITLE
Add `cito-oss/tempo`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -199,6 +199,7 @@ Multi-language or language-agnostic samples. (For samples in a specific lang, se
 - [`saga420/temporal-encryption-converter`](https://github.com/saga420/temporal-encryption-converter) - The Temporal Encryption Converter is a Go package that provides secure communication and context propagation for the Temporal workflow engine, employing AES256_GCM_PBKDF2_Curve25519 and XChaCha20_Poly1305_PBKDF2_Curve25519 encryption algorithms and ZLib compression.
 - [`hatchet-dev/hatchet-workflows`](https://github.com/hatchet-dev/hatchet-workflows) - YAML DSL workflows.
 - [`vikstrous/tempts`](https://github.com/vikstrous/tempts) - Opinionated and type-safe wrappers for the Go SDK.
+- [`cito-oss/tempo`](https://github.com/cito-oss/tempo) - Run distributed Go-like tests using Temporal.
 
 ### Tutorials
 


### PR DESCRIPTION
[URL](https://github.com/cito-oss/tempo)

Tempo is a wrapper library that allows creating Go-like tests to run it using Temporal.