### PR TITLE
[README] Add open-responses and julep projects in "Built-with Temporal" section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -379,7 +379,7 @@ Multi-language or language-agnostic samples. (For samples in a specific lang, se
 - [Cron Atlas](https://github.com/pmbanugo/cron-atlas) - Hit an HTTP endpoint on a schedule
 - [PeerDB data synchronization](https://blog.peerdb.io/using-temporal-to-scale-data-synchronization-at-peerdb)
 - [Julep: Modern, Scalable, Resilient AI workflows](https://github.com/julep-ai/julep)
-- [Open Responses: Self-hosted alternative to OpenAI's Responses API that works with any model](https://github.com/julep-ai/open-responses) [![GitHub Repo stars](https://img.shields.io/github/stars/julep-ai/open-responses?style=social&link=https%3A%2F%2Fgithub.com%2Fjulep-ai%2Fopen-responses&link=https%3A%2F%2Fgithub.com%2Fjulep-ai%2Fopen-responses)](https://github.com/julep-ai/open-responses)
+- [Open Responses: Self-hosted alternative to OpenAI's Responses API that works with any model](https://github.com/julep-ai/open-responses)
 
 ## Credits
 

--- a/readme.md
+++ b/readme.md
@@ -378,7 +378,7 @@ Multi-language or language-agnostic samples. (For samples in a specific lang, se
 - [Building a better Mouse Trap – web crawling with Temporal](https://javapro.io/2024/10/03/building-a-better-mouse-trap-web-crawling-with-temporal/) by @spoole167
 - [Cron Atlas](https://github.com/pmbanugo/cron-atlas) - Hit an HTTP endpoint on a schedule
 - [PeerDB data synchronization](https://blog.peerdb.io/using-temporal-to-scale-data-synchronization-at-peerdb)
-- [Julep: Modern, Scalable, Resilient AI workflows](https://github.com/julep-ai/julep) [![GitHub Repo stars](https://img.shields.io/github/stars/julep-ai/julep?style=social&link=https%3A%2F%2Fgithub.com%2Fjulep-ai%2Fjulep&link=https%3A%2F%2Fgithub.com%2Fjulep-ai%2Fjulep)](https://github.com/julep-ai/julep)
+- [Julep: Modern, Scalable, Resilient AI workflows](https://github.com/julep-ai/julep)
 - [Open Responses: Self-hosted alternative to OpenAI's Responses API that works with any model](https://github.com/julep-ai/open-responses) [![GitHub Repo stars](https://img.shields.io/github/stars/julep-ai/open-responses?style=social&link=https%3A%2F%2Fgithub.com%2Fjulep-ai%2Fopen-responses&link=https%3A%2F%2Fgithub.com%2Fjulep-ai%2Fopen-responses)](https://github.com/julep-ai/open-responses)
 
 ## Credits

--- a/readme.md
+++ b/readme.md
@@ -378,10 +378,12 @@ Multi-language or language-agnostic samples. (For samples in a specific lang, se
 - [Building a better Mouse Trap – web crawling with Temporal](https://javapro.io/2024/10/03/building-a-better-mouse-trap-web-crawling-with-temporal/) by @spoole167
 - [Cron Atlas](https://github.com/pmbanugo/cron-atlas) - Hit an HTTP endpoint on a schedule
 - [PeerDB data synchronization](https://blog.peerdb.io/using-temporal-to-scale-data-synchronization-at-peerdb)
+- [Julep: Modern, Scalable, Resilient AI workflows](https://github.com/julep-ai/julep) [![GitHub Repo stars](https://img.shields.io/github/stars/julep-ai/julep?style=social&link=https%3A%2F%2Fgithub.com%2Fjulep-ai%2Fjulep&link=https%3A%2F%2Fgithub.com%2Fjulep-ai%2Fjulep)](https://github.com/julep-ai/julep)
+- [Open Responses: Self-hosted alternative to OpenAI's Responses API that works with any model](https://github.com/julep-ai/open-responses) [![GitHub Repo stars](https://img.shields.io/github/stars/julep-ai/open-responses?style=social&link=https%3A%2F%2Fgithub.com%2Fjulep-ai%2Fopen-responses&link=https%3A%2F%2Fgithub.com%2Fjulep-ai%2Fopen-responses)](https://github.com/julep-ai/open-responses)
 
 ## Credits
 
-We welcome contributions! See [`contributing.md`](contributing.md).
+We welcome contributions! See [`contributing.md`](contributing.md). 
 
 🙏 Thank you to: 
 


### PR DESCRIPTION
Added our projects to the "Built with temporal" section:
- https://github.com/julep-ai/open-responses
- https://github.com/julep-ai/julep

Thanks and kudos to the temporal team!