### PR TITLE
Add agenticenv/agent-sdk-go to Go Libraries

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -207,6 +207,7 @@ Multi-language or language-agnostic samples. (For samples in a specific lang, se
 
 ### Libraries
 
+- [agenticenv/agent-sdk-go](https://github.com/agenticenv/agent-sdk-go) - Temporal-first framework for building durable, production-grade AI agents in Go with native tools, MCP, human-in-the-loop approvals, and sub-agent delegation.
 - [`Courtsite/temporal-go-helpers`](https://github.com/Courtsite/temporal-go-helpers) - Collection of helpers: saga, receive Signal with timeout, drain channel.
 - [`zboralski/codecserver`](https://github.com/zboralski/codecserver) - Data Converter and Codec Server that uses Transit Secrets Engine from HashiCorp Vault.
 - [`saga420/temporal-encryption-converter`](https://github.com/saga420/temporal-encryption-converter) - The Temporal Encryption Converter is a Go package that provides secure communication and context propagation for the Temporal workflow engine, employing AES256_GCM_PBKDF2_Curve25519 and XChaCha20_Poly1305_PBKDF2_Curve25519 encryption algorithms and ZLib compression.


### PR DESCRIPTION
Added agenticenv/agent-sdk-go to the Go Libraries section. It is a framework for building durable AI agents using Temporal, featuring MCP support and human-in-the-loop approvals.

URL: https://github.com/agenticenv/agent-sdk-go

Why it's awesome:
A Go SDK for building durable AI agents on Temporal. It supports tools, Model Context Protocol (MCP), human-in-the-loop approvals, and sub-agent delegation, enabling reliable, long-running agent workflows with production-grade orchestration.

Note: Placed in alphabetical order within the Go Libraries section.