### PR TITLE
Add awaithumans to Frameworks — HITL primitive for AI agents

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -121,6 +121,7 @@ Temporal is a [durable execution system](https://youtu.be/W0Ygep6iCJY?t=609). It
 
 ## Frameworks
 
+- [awaithumans](https://github.com/awaithumans/awaithumans) - HITL primitive for AI agents. One function call (`await_human` / `awaitHuman`) suspends the workflow until a real person reviews via Slack, email, or a built-in dashboard, then resumes with the typed response. The Temporal adapter uses signals to park the workflow while it waits — durable across worker restarts. Python + TypeScript SDKs, Apache 2.0.
 - [iWF](https://github.com/indeedeng/iwf) - DSL workflow framework built on Temporal.
 - [Output](https://github.com/growthxai/output) - AI Agents & Workflows with versioned prompts, evals, tracing, and credentials in one TypeScript framework built on Temporal.
 


### PR DESCRIPTION
Adds **awaithumans** to the **Frameworks** section.

A one-function-call human-in-the-loop primitive for AI agents (`await_human` / `awaitHuman`). The Temporal adapter uses signals to park the workflow while a human reviews via Slack / email / web dashboard, then resumes with the typed Pydantic / Zod response. Durable across worker restarts via Stripe-style idempotency keys.

- Apache 2.0
- Python + TypeScript SDKs with matching wire format
- LangGraph adapter also included
- Optional AI verifier (Claude / OpenAI / Gemini / Azure, BYO key)
- Repo: https://github.com/awaithumans/awaithumans
- Docs: https://docs.awaithumans.dev
- Temporal adapter guide: https://docs.awaithumans.dev/adapters/temporal

Happy to revise placement or description if there's a better fit.