### PR TITLE
Add temporalio/samples-dotnet to the .NET Samples section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -328,6 +328,8 @@ Multi-language or language-agnostic samples. (For samples in a specific lang, se
 
 ### Samples
 
+- [`temporalio/samples-dotnet`](https://github.com/temporalio/samples-dotnet)
+
 ### Libraries
 
 - [InfinityFlow.Aspire.Temporal](https://github.com/InfinityFlowApp/aspire-temporal) - A [.NET Aspire](https://learn.microsoft.com/en-us/dotnet/aspire) package to work with `temporal` and start a dev server.


### PR DESCRIPTION
The `.NET` → `Samples` subsection is empty, while the Go, TypeScript, Java, and Python sections all list their official `temporalio/samples-*` repository there. This adds the official .NET SDK samples repo to match that convention.

- https://github.com/temporalio/samples-dotnet — "Samples for working with the Temporal .NET SDK", actively maintained.
