### PR TITLE
Add PHP SDK API reference link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -345,6 +345,7 @@ Multi-language or language-agnostic samples. (For samples in a specific lang, se
 
 - [PHP SDK](https://github.com/temporalio/sdk-php)
 - [PHP SDK docs](https://t.mp/php)
+- [PHP SDK API reference](https://php.temporal.io)
 
 ### Samples
 


### PR DESCRIPTION
The `PHP` section links the SDK repo and its docs, but not its API reference — unlike Go, TypeScript, Java, and Python, which all list an API reference. This adds the official PHP SDK API reference:

- https://php.temporal.io — auto-generated Temporal PHP SDK API reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
