### PR TITLE
Add Ruby SDK API reference and samples-ruby links

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -370,8 +370,11 @@ Multi-language or language-agnostic samples. (For samples in a specific lang, se
 ## Ruby
 
 - [Ruby SDK](https://github.com/temporalio/sdk-ruby)
+- [Ruby SDK API reference](https://ruby.temporal.io)
 
 ### Samples
+
+- [`temporalio/samples-ruby`](https://github.com/temporalio/samples-ruby)
 
 ### Libraries
 


### PR DESCRIPTION
The `Ruby` section is missing two official links that the Ruby SDK's own README points to — the API reference, and the samples repo (the `Samples` subsection is currently empty). This adds both, matching the convention used by the other language sections:

- https://ruby.temporal.io — Ruby SDK API reference (YARD).
- https://github.com/temporalio/samples-ruby — official Temporal Ruby SDK samples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
