### PR TITLE
Relabel Java docs link to Java SDK docs for consistency

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -276,7 +276,7 @@ Multi-language or language-agnostic samples. (For samples in a specific lang, se
 ## Java
 
 - [Java SDK](https://github.com/temporalio/sdk-java)
-- [Java SDK](https://t.mp/java)
+- [Java SDK docs](https://t.mp/java)
 - [Java SDK API reference](https://t.mp/java-api)
 
 ### Samples


### PR DESCRIPTION
The `Java` section's docs link is labeled `Java SDK`, which duplicates the label of the SDK-repo link on the line directly above it. Every other language labels this link `<Lang> SDK docs`. This renames it to `Java SDK docs` for consistency — label only, the URL (`t.mp/java`) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
