### PR TITLE
Add Rust SDK section (Public Preview)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -66,6 +66,7 @@ Temporal is a [durable execution system](https://youtu.be/W0Ygep6iCJY?t=609). It
   - [Libraries](#libraries-7)
   - [Tutorials](#tutorials-6)
   - [Blog posts](#blog-posts-7)
+- [Rust](#rust)
 - [Clojure](#clojure)
 - [Elixir](#elixir)
 - [Erlang](#erlang)
@@ -378,6 +379,12 @@ Multi-language or language-agnostic samples. (For samples in a specific lang, se
 ### Tutorials
 
 ### Blog posts
+
+## Rust
+
+- [Rust SDK](https://github.com/temporalio/sdk-rust) - Currently in Public Preview.
+- [`temporalio-sdk` crate](https://crates.io/crates/temporalio-sdk)
+- [Rust SDK API reference](https://docs.rs/temporalio-sdk)
 
 ## Clojure
 


### PR DESCRIPTION
Temporal now ships a first-party **Rust SDK** (currently in Public Preview), but the list has no Rust section — even though Rust is already named under “Languages we have SDKs in”. This adds a `Rust` section plus its TOC entry, mirroring the layout of the other language sections:

- https://github.com/temporalio/sdk-rust — Temporal Rust SDK (Public Preview).
- https://crates.io/crates/temporalio-sdk — published crate (v0.5.0).
- https://docs.rs/temporalio-sdk — API reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
