### PR TITLE
Add temporal-postgres-visibility to Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -115,6 +115,7 @@ Temporal is a [durable execution system](https://youtu.be/W0Ygep6iCJY?t=609). It
 - [`rross/temporal-cloud-run`](https://github.com/rross/temporal-cloud-run) - Pulumi scripts for creating and configuring a Google Cloud Project and using Cloud Build to deploy a Temporal worker and the Open Telemetry Connector in Cloud Run
 - [`northpowered/temporal-rest-executor`](https://github.com/northpowered/temporal-rest-executor) - Simple REST server (with Swagger UI) to execute any activity/workflow in Temporal namespace. Useful for development and I&T.
 - [`tempo`](https://miketoscano.com/tempo/) - Tempo is an app available for iOS, Android, and Linux for monitoring, searching, debugging, and managing Temporal Workflows, schedules, and batch operations.
+- [`Krishnachaitanyakc/temporal-postgres-visibility`](https://github.com/Krishnachaitanyakc/temporal-postgres-visibility) - Reduces PostgreSQL Visibility index bloat by converting unused Search Attribute indexes on `executions_visibility` to partial indexes, with a REINDEX and autovacuum runbook.
 
 ### Terraform Providers
 


### PR DESCRIPTION
Adds `Krishnachaitanyakc/temporal-postgres-visibility` under Tools. It addresses the PostgreSQL Visibility index bloat in temporalio/temporal#10145 with a migration converting unused Search Attribute indexes to partial indexes, a reproducible benchmark, and a `REINDEX`/autovacuum runbook. Only a list item is added, so the generated table of contents is unchanged.